### PR TITLE
Adds a little mcse check for standard normal example

### DIFF
--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -65,6 +65,7 @@ if (WALNUTS_BUILD_EXAMPLES)
   add_executable(test_nuts ${CMAKE_CURRENT_SOURCE_DIR}/examples/test.cpp)
   target_link_libraries(test_nuts PRIVATE Eigen3::Eigen walnuts::walnuts)
   target_compile_options(test_nuts PRIVATE -O3 -Wall)
+  target_include_directories(test_nuts PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/examples)
 endif()
 
 

--- a/walnuts_cpp/examples/check_mcse.hpp
+++ b/walnuts_cpp/examples/check_mcse.hpp
@@ -20,7 +20,7 @@ inline double failure_prob(double mcse_dev) {
 }
 
 // Approximate Binomial(K,p0) upper‐tail P(X ≥ n_fail) via normal‐approx
-double binom_omnibus_normal(int K, int n_fail, double p0) {
+double binom_test(int K, int n_fail, double p0) {
   double mean = K * p0;
   double var = K * p0 * (1.0 - p0);
   if (var <= 0.0)
@@ -40,11 +40,13 @@ struct McseResult {
 // ——— Updated check_mcse ———
 template <typename S>
 McseResult check_mcse(const Eigen::Matrix<S, -1, -1> &draws,
+                      const Eigen::Matrix<S, -1, 1>& true_means,
+                      const Eigen::Matrix<S, -1, 1>& true_m2s,
                       S tolerance = 1e-8, S mcse_deviation = 3.0,
                       int max_fails = -1) {
   const int D = draws.rows();
   const int N = draws.cols();
-  // Default heuristic assumes 
+  // Default heuristic assumes
   S p_fail = internal::failure_prob(mcse_deviation);
   if (max_fails < 0) {
     S mean = D * p_fail;
@@ -56,38 +58,40 @@ McseResult check_mcse(const Eigen::Matrix<S, -1, -1> &draws,
   }
 
   int num_mean_fails = 0;
-  int num_var_fails = 0;
+  int num_m2_fails = 0;
+  auto mean_v = draws.rowwise().mean().eval();
+  auto m2_v = draws.array().square().rowwise().mean().eval();
   for (int d = 0; d < D; ++d) {
     // — sample mean & variance —
-    S mean = draws.row(d).mean();
-    S var = (draws.row(d).array() - mean).square().sum() / (N - 1);
-
+    auto true_mean = true_means(d);
+    auto mean = mean_v(d);
+    auto true_m2 = true_m2s(d);
+    auto m2 = m2_v(d);
     // — mean test —
-    S se_mean = std::sqrt(var / N);
+    S se_mean = std::sqrt(true_m2 / N);
     S se_mean_dev = se_mean * mcse_deviation;
     S mean_threshold = std::max(
         tolerance * 0.5 * (std::fabs(mean) + std::fabs(se_mean_dev)), 1e-14);
-    if (std::fabs(mean) - se_mean_dev > mean_threshold) {
+    if (std::fabs(mean - true_mean) - se_mean_dev > mean_threshold) {
       num_mean_fails++;
     }
 
     // — variance test —
-    S se_var = std::sqrt(2.0 * var * var / (N - 1));
-    S se_var_dev = se_var * mcse_deviation;
-    S var_threshold = std::max(
-        tolerance * 0.5 * (std::fabs(var - 1.0) + std::fabs(se_var_dev)),
-        1e-14);
-    if (std::fabs(var - 1.0) - se_var_dev > var_threshold) {
-      num_var_fails++;
+    S se_m2 = std::sqrt(2.0 * m2 * m2 / (N - 1));
+    S se_m2_dev = se_m2 * mcse_deviation;
+    S m2_threshold = std::max(
+        tolerance * 0.5 * (std::fabs(m2) + std::fabs(se_m2_dev)), 1e-14);
+    if (std::fabs(m2 - true_m2) - se_m2_dev > m2_threshold) {
+      num_m2_fails++;
     }
   }
 
   // — compute omnibus p-value —
   // here we treat each test (mean+var) separately → K = 2D
-  double pval_means = internal::binom_omnibus_normal(D, num_mean_fails, p_fail);
-  double pval_vars = internal::binom_omnibus_normal(D, num_var_fails, p_fail);
+  double pval_means = internal::binom_test(D, num_mean_fails, p_fail);
+  double pval_m2s = internal::binom_test(D, num_m2_fails, p_fail);
 
-  const bool failed = (pval_means < 0.01 || pval_vars < 0.01);
+  const bool failed = (pval_means < 0.01 || pval_m2s < 0.01);
   if (failed) {
     std::cerr << "\n*************"
                  "\n** WARNING **"
@@ -95,17 +99,17 @@ McseResult check_mcse(const Eigen::Matrix<S, -1, -1> &draws,
     if (pval_means < 0.01) {
       std::cout << "\tMean test failed " << num_mean_fails << " out of " << D << " times\n";
     }
-    if (pval_vars < 0.01) {
-      std::cout << "\tVariance test failed " << num_var_fails << " out of " << D << " times\n";
+    if (pval_m2s < 0.01) {
+      std::cout << "\tsecond moment test failed " << num_m2_fails << " out of " << D << " times\n";
     }
   }
 
   std::cout << "Mean:\n\tfailures =  " << num_mean_fails << "\n";
   std::cout << "\tp-value  =  " << pval_means << "\n";
-  std::cout << "Variance\n\tfailures =  " << num_var_fails << "\n";
-  std::cout << "\tp-value  =  " << pval_vars << "\n";
+  std::cout << "second moment\n\tfailures =  " << num_m2_fails << "\n";
+  std::cout << "\tp-value  =  " << pval_m2s << "\n";
 
-  return McseResult{num_mean_fails + num_var_fails, pval_means, pval_vars, !failed};
+  return McseResult{num_mean_fails + num_m2_fails, pval_means, pval_m2s, !failed};
 }
 
 } // namespace walnuts::test

--- a/walnuts_cpp/examples/check_mcse.hpp
+++ b/walnuts_cpp/examples/check_mcse.hpp
@@ -1,0 +1,113 @@
+#ifndef WALNUTS_EXAMPLES_MCSE_CHECK
+#define WALNUTS_EXAMPLES_MCSE_CHECK
+
+#include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+namespace walnuts::test {
+
+namespace internal {
+// Standard normal CDF via std::erf
+inline double Phi(double x) {
+  return 0.5 * (1.0 + std::erf(x / std::sqrt(2.0)));
+}
+
+// Compute per‐trial failure probability p0 = P(|Z| > mcse_dev) for Z∼N(0,1)
+inline double failure_prob(double mcse_dev) {
+  return std::erfc(mcse_dev / std::sqrt(2.0));
+}
+
+// Approximate Binomial(K,p0) upper‐tail P(X ≥ n_fail) via normal‐approx
+double binom_omnibus_normal(int K, int n_fail, double p0) {
+  double mean = K * p0;
+  double var = K * p0 * (1.0 - p0);
+  if (var <= 0.0)
+    return (n_fail > mean ? 0.0 : 1.0);
+  double Z = (n_fail - mean) / std::sqrt(var);
+  return 1.0 - Phi(Z); // one‐sided
+}
+} // namespace internal
+// ——— Result struct ———
+struct McseResult {
+  int num_fails;  // total mean+variance failures
+  double p_value_mean; // omnibus binomial p-value
+  double p_value_vars;
+  bool passed;    // num_fails ≤ max_fails
+};
+
+// ——— Updated check_mcse ———
+template <typename S>
+McseResult check_mcse(const Eigen::Matrix<S, -1, -1> &draws,
+                      S tolerance = 1e-8, S mcse_deviation = 3.0,
+                      int max_fails = -1) {
+  const int D = draws.rows();
+  const int N = draws.cols();
+  // Default heuristic assumes 
+  S p_fail = internal::failure_prob(mcse_deviation);
+  if (max_fails < 0) {
+    S mean = D * p_fail;
+    S var = D * p_fail * (1.0 - p_fail);
+    S sd = std::sqrt(var);
+    int m = static_cast<int>(std::ceil(mean + mcse_deviation * sd));
+    max_fails = std::max(m + 1, 1);
+    std::cout << "max_fails default = " << max_fails << "\n";
+  }
+
+  int num_mean_fails = 0;
+  int num_var_fails = 0;
+  for (int d = 0; d < D; ++d) {
+    // — sample mean & variance —
+    S mean = draws.row(d).mean();
+    S var = (draws.row(d).array() - mean).square().sum() / (N - 1);
+
+    // — mean test —
+    S se_mean = std::sqrt(var / N);
+    S se_mean_dev = se_mean * mcse_deviation;
+    S mean_threshold = std::max(
+        tolerance * 0.5 * (std::fabs(mean) + std::fabs(se_mean_dev)), 1e-14);
+    if (std::fabs(mean) - se_mean_dev > mean_threshold) {
+      num_mean_fails++;
+    }
+
+    // — variance test —
+    S se_var = std::sqrt(2.0 * var * var / (N - 1));
+    S se_var_dev = se_var * mcse_deviation;
+    S var_threshold = std::max(
+        tolerance * 0.5 * (std::fabs(var - 1.0) + std::fabs(se_var_dev)),
+        1e-14);
+    if (std::fabs(var - 1.0) - se_var_dev > var_threshold) {
+      num_var_fails++;
+    }
+  }
+
+  // — compute omnibus p-value —
+  // here we treat each test (mean+var) separately → K = 2D
+  double pval_means = internal::binom_omnibus_normal(D, num_mean_fails, p_fail);
+  double pval_vars = internal::binom_omnibus_normal(D, num_var_fails, p_fail);
+
+  const bool failed = (pval_means < 0.01 || pval_vars < 0.01);
+  if (failed) {
+    std::cerr << "\n*************"
+                 "\n** WARNING **"
+                 "\n*************\n";
+    if (pval_means < 0.01) {
+      std::cout << "\tMean test failed " << num_mean_fails << " out of " << D << " times\n";
+    }
+    if (pval_vars < 0.01) {
+      std::cout << "\tVariance test failed " << num_var_fails << " out of " << D << " times\n";
+    }
+  }
+
+  std::cout << "Mean:\n\tfailures =  " << num_mean_fails << "\n";
+  std::cout << "\tp-value  =  " << pval_means << "\n";
+  std::cout << "Variance\n\tfailures =  " << num_var_fails << "\n";
+  std::cout << "\tp-value  =  " << pval_vars << "\n";
+
+  return McseResult{num_mean_fails + num_var_fails, pval_means, pval_vars, !failed};
+}
+
+} // namespace walnuts::test
+
+#endif

--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -48,8 +48,8 @@ int check_mcse(const Eigen::Matrix<S, -1, -1>& draws,
     double var  = D * p_fail * (1.0 - p_fail);
     double sd   = std::sqrt(var);
     int m = static_cast<int>(std::ceil(mean + mcse_deviation * sd));
-    // never return less than 1
-    max_fails = std::max(m, 1);
+    // never return less than 1 (and add one for a little wiggle room)
+    max_fails = std::max(m + 1, 1);
     std::cout << "max_fails default = " << max_fails << "\n";
   }
   int num_mean_fails = 0;

--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -58,7 +58,6 @@ int check_mcse(const Eigen::Matrix<S, -1, -1>& draws,
 
     S abs_mean = std::fabs(mean);
     if (abs_mean > se_mean_dev + mean_threshold) {
-      S diff_from_mcse      = abs_mean - se_mean_dev;
       S diff_from_total_tol = abs_mean - (se_mean_dev + mean_threshold);
 
       std::cerr
@@ -80,7 +79,6 @@ int check_mcse(const Eigen::Matrix<S, -1, -1>& draws,
 
     S abs_var_diff = std::fabs(var - 1.0);
     if (abs_var_diff > se_var_dev + var_threshold) {
-      S diff_from_mcse      = abs_var_diff - se_var_dev;
       S diff_from_total_tol = abs_var_diff - (se_var_dev + var_threshold);
 
       std::cerr

--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -65,7 +65,9 @@ void test_nuts(const VectorS &theta_init, G &generator, int D, int N,
   if (D > 10) {
     std::cout << "... elided " << (D - 5) << " dimensions ..." << std::endl;
   }
-  walnuts::test::check_mcse(draws);
+  Eigen::Matrix<S, -1, 1> true_means = VectorS::Zero(D);
+  Eigen::Matrix<S, -1, 1> true_m2s = VectorS::Ones(D);
+  walnuts::test::check_mcse(draws, true_means, true_m2s);
 
 }
 


### PR DESCRIPTION
The check here is to make sure a "majority" of the means and variances are within a tolerance of the monte carlo standard error. Majority here means either a value set by the user or a small heuristic to figure out how many of the standard normals would fall outside of the MCSE by chance.

Example output:

```
cmake -S . -B "build"
cmake --build build --target test_nuts 
./build/test_nuts 

# Output
D = 200;  N = 5000;  step_size = 0.025;  max_depth = 10
    total time: 0.825501s
logp_grad time: 0.0911676s
logp_grad fraction: 0.110439
        logp_grad calls: 639872
        time per call: 1.42478e-07s

dim 0: mean = 0.00104477, stddev = 0.98401
dim 1: mean = -0.00897926, stddev = 1.00702
dim 2: mean = -0.00436875, stddev = 1.00377
dim 3: mean = 0.00383368, stddev = 0.99562
dim 4: mean = -0.000803738, stddev = 1.00549
dim 5: mean = 0.0135532, stddev = 1.0115
dim 6: mean = -0.00110094, stddev = 0.99067
dim 7: mean = -0.00495788, stddev = 0.984748
dim 8: mean = -0.0255179, stddev = 1.01567
dim 9: mean = 0.00370702, stddev = 1.01289
... elided 190 dimensions ...
max_fails default = 4

[MCSE FAILURE] Dimension 108 (mean test)
  Sample mean                  = 0.0453432
  abs(mean)                    = 0.0453432
  MCSE                         = 0.0142635
  adjusted relative threshold  = 4.40669e-10
  mcse_deviation               = 3
  MCSE * deviation + threshold = 0.0427905
  Exceeded total bound by      = 0.00255272

[MCSE FAILURE] Dimension 130 (var test)
  Sample var                    = 1.09518
  abs(var - 1)                  = 0.0951837
  MCSE                          = 0.0219059
  adjusted relative threshold   = 8.04507e-10
  mcse_deviation                = 3
  MCSE * deviation + threshold  = 0.0657176
  Exceeded total bound by       = 0.0294661

[MCSE FAILURE] Dimension 145 (var test)
  Sample var                    = 0.920379
  abs(var - 1)                  = 0.0796213
  MCSE                          = 0.0184094
  adjusted relative threshold   = 6.74248e-10
  mcse_deviation                = 3
  MCSE * deviation + threshold  = 0.0552282
  Exceeded total bound by       = 0.024393
Mean failures: 1
Var failures:  2
```