### PR TITLE
log density reuse for macro_step

### DIFF
--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -23,24 +23,28 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING
 ##########################
 ## Global Dependencies  ##
 ##########################
-include(FetchContent)
+find_package(Git REQUIRED)
 
-FetchContent_Declare(
-  Eigen
-  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-  GIT_TAG        3.4.0
+# where to put Eigen
+set(EIGEN_SRC_DIR "${CMAKE_BINARY_DIR}/_deps/eigen")
+set(EIGEN_TAG 3.4.0)
+# only clone on first configure
+if(NOT EXISTS "${EIGEN_SRC_DIR}/Eigen")
+  message(STATUS "Cloning Eigen ${EIGEN_TAG}…")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} clone --branch ${EIGEN_TAG} --depth 1 -- https://gitlab.com/libeigen/eigen.git ${EIGEN_SRC_DIR}
+    RESULT_VARIABLE _git_result
+  )
+  if(NOT _git_result EQUAL 0)
+    message(FATAL_ERROR "Git clone of Eigen failed")
+  endif()
+endif()
+
+# now expose it as a pure‐header interface target
+add_library(Eigen3::Eigen INTERFACE IMPORTED)
+target_include_directories(Eigen3::Eigen INTERFACE
+  "${EIGEN_SRC_DIR}"
 )
-FetchContent_Populate(Eigen)   # ⇒ eigen_SOURCE_DIR / eigen_BINARY_DIR
-# 1) Create an INTERFACE library for the headers
-add_library(eigen_headers INTERFACE)
-target_include_directories(eigen_headers
-  INTERFACE
-    ${eigen_SOURCE_DIR}      # root of Eigen repo: contains Eigen/ and unsupported/
-)
-# 2) Alias it so downstream CMakeLists can do find-like targets
-add_library(Eigen3::Eigen ALIAS eigen_headers)
-
-
 #############################
 ## Making Walnuts Library  ##
 #############################

--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -1,4 +1,5 @@
 #include <walnuts/nuts.hpp>
+#include <walnuts/walnuts.hpp>
 #include <chrono>
 #include <cmath>
 #include <iostream>
@@ -24,28 +25,21 @@ void standard_normal_logp_grad(const Eigen::Matrix<T, Eigen::Dynamic, 1> &x,
   ++count;
 }
 
-int main() {
-  int init_seed = 333456;
-  int seed = 763545;
-  int D = 200;
-  int N = 5000;
-  S step_size = 0.025;
-  int max_depth = 10;
-  VectorS inv_mass = VectorS::Ones(D);
+template <bool W, typename G>
+void test_nuts(const VectorS& theta_init, G& generator, int D, int N, S step_size, S max_depth,
+	       S max_error, const VectorS& inv_mass) {
   MatrixS draws(D, N);
-  std::cout << "D = " << D << ";  N = " << N << ";  step_size = " << step_size
-            << ";  max_depth = " << max_depth << std::endl;
-
-  std::mt19937 generator(init_seed);
-  std::normal_distribution<S> std_normal(0.0, 1.0);
-  VectorS theta_init(D);
-  for (int i = 0; i < D; ++i) {
-    theta_init(i) = std_normal(generator);
-  }
+  std::cout << std::endl << "D = " << D << ";  N = " << N << ";  step_size = " << step_size
+            << ";  max_depth = " << max_depth << ";  WALNUTS = " << (W ? "true" : "false") << std::endl;
 
   auto global_start = std::chrono::high_resolution_clock::now();
-  nuts::nuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,
-             max_depth, theta_init, draws);
+  if constexpr (W) {
+    walnuts::walnuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,
+		     max_depth, max_error, theta_init, draws);
+  } else {
+    nuts::nuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,
+	       max_depth, theta_init, draws);
+  }
   auto global_end = std::chrono::high_resolution_clock::now();
   auto global_total_time =
       std::chrono::duration<double>(global_end - global_start).count();
@@ -59,7 +53,7 @@ int main() {
             << std::endl;
   std::cout << std::endl;
 
-  for (int d = 0; d < std::min(D, 10); ++d) {
+  for (int d = 0; d < std::min(D, 5); ++d) {
     auto mean = draws.row(d).mean();
     auto var = (draws.row(d).array() - mean).square().sum() / (N - 1);
     auto stddev = std::sqrt(var);
@@ -67,7 +61,28 @@ int main() {
               << "\n";
   }
   if (D > 10) {
-    std::cout << "... elided " << (D - 10) << " dimensions ..." << std::endl;
+    std::cout << "... elided " << (D - 5) << " dimensions ..." << std::endl;
   }
+}
+
+int main() {
+  int seed = 763545;
+  int D = 200;
+  int N = 5000;
+  S step_size = 0.1;
+  int max_depth = 10;
+  S max_error = 0.05;
+  VectorS inv_mass = VectorS::Ones(D);
+
+  std::mt19937 generator(seed);
+  std::normal_distribution<S> std_normal(0.0, 1.0);
+  VectorS theta_init(D);
+  for (int i = 0; i < D; ++i) {
+    theta_init(i) = std_normal(generator);
+  }
+
+  test_nuts<false>(theta_init, generator, D, N, step_size, max_depth, max_error, inv_mass);
+  test_nuts<true>(theta_init, generator, D, N, step_size, max_depth, max_error, inv_mass);
+    
   return 0;
 }

--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -81,7 +81,7 @@ int main() {
   int N = 5000;
   S step_size = 0.25;
   int max_depth = 10;
-  S max_error = 0.2;
+  S max_error = 0.2;  // 80% Metropolis, 45% Barker
   VectorS inv_mass = VectorS::Ones(D);
 
   std::mt19937 generator(seed);

--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -10,6 +10,9 @@ using S = double;
 using VectorS = Eigen::Matrix<S, -1, 1>;
 using MatrixS = Eigen::Matrix<S, -1, -1>;
 
+enum class Sampler { Nuts, Walnuts };
+
+
 double total_time = 0.0;
 int count = 0;
 
@@ -25,18 +28,25 @@ void standard_normal_logp_grad(const Eigen::Matrix<T, Eigen::Dynamic, 1> &x,
   ++count;
 }
 
-template <bool W, typename G>
+template <Sampler U, typename G>
 void test_nuts(const VectorS& theta_init, G& generator, int D, int N, S step_size, S max_depth,
 	       S max_error, const VectorS& inv_mass) {
+  total_time = 0.0;
+  count = 0;
   MatrixS draws(D, N);
-  std::cout << std::endl << "D = " << D << ";  N = " << N << ";  step_size = " << step_size
-            << ";  max_depth = " << max_depth << ";  WALNUTS = " << (W ? "true" : "false") << std::endl;
+  std::cout << std::endl
+	    << "D = " << D
+	    << ";  N = " << N
+	    << ";  step_size = " << step_size
+            << ";  max_depth = " << max_depth
+	    << ";  WALNUTS = " << (U == Sampler::Walnuts ? "true" : "false")
+	    << std::endl;
 
   auto global_start = std::chrono::high_resolution_clock::now();
-  if constexpr (W) {
+  if constexpr (U == Sampler::Walnuts) {
     walnuts::walnuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,
 		     max_depth, max_error, theta_init, draws);
-  } else {
+  } else if constexpr (U == Sampler::Nuts) {
     nuts::nuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,
 	       max_depth, theta_init, draws);
   }
@@ -66,12 +76,12 @@ void test_nuts(const VectorS& theta_init, G& generator, int D, int N, S step_siz
 }
 
 int main() {
-  int seed = 763545;
+  int seed = 428763;
   int D = 200;
   int N = 5000;
-  S step_size = 0.1;
+  S step_size = 0.25;
   int max_depth = 10;
-  S max_error = 0.05;
+  S max_error = 0.2;
   VectorS inv_mass = VectorS::Ones(D);
 
   std::mt19937 generator(seed);
@@ -81,8 +91,8 @@ int main() {
     theta_init(i) = std_normal(generator);
   }
 
-  test_nuts<false>(theta_init, generator, D, N, step_size, max_depth, max_error, inv_mass);
-  test_nuts<true>(theta_init, generator, D, N, step_size, max_depth, max_error, inv_mass);
+  test_nuts<Sampler::Nuts>(theta_init, generator, D, N, step_size, max_depth, max_error, inv_mass);
+  test_nuts<Sampler::Walnuts>(theta_init, generator, D, N, step_size, max_depth, max_error, inv_mass);
     
   return 0;
 }

--- a/walnuts_cpp/include/walnuts/walnuts.hpp
+++ b/walnuts_cpp/include/walnuts/walnuts.hpp
@@ -1,0 +1,314 @@
+#include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <utility>
+
+namespace walnuts {
+
+template <typename S> using Vec = Eigen::Matrix<S, Eigen::Dynamic, 1>;
+
+template <typename S>
+using Matrix = Eigen::Matrix<S, Eigen::Dynamic, Eigen::Dynamic>;
+
+using Integer = std::int32_t;
+
+enum class Update { Barker, Metropolis };
+
+enum class Direction { Backward, Forward };
+
+template <typename S, class Generator> class Random {
+public:
+  explicit Random(Generator &rng)
+      : rng_(rng), unif_(0.0, 1.0), binary_(0.5), normal_(0.0, 1.0) {}
+
+  inline S uniform_real_01() { return unif_(rng_); }
+
+  inline bool uniform_binary() { return binary_(rng_); }
+
+  inline Vec<S> standard_normal(Integer n) {
+    return Vec<S>::NullaryExpr(n, [&](Integer) { return normal_(rng_); });
+  }
+
+private:
+  Generator &rng_;
+  std::uniform_real_distribution<S> unif_;
+  std::bernoulli_distribution binary_;
+  std::normal_distribution<S> normal_;
+};
+
+template <typename S> class Span {
+public:
+  Vec<S> theta_bk_;
+  Vec<S> rho_bk_;
+  Vec<S> grad_theta_bk_;
+  Vec<S> theta_fw_;
+  Vec<S> rho_fw_;
+  Vec<S> grad_theta_fw_;
+  Vec<S> theta_select_;
+  S logp_;
+
+  Span(Vec<S> &&theta, Vec<S> &&rho, Vec<S> &&grad_theta,
+       S logp)
+      : theta_bk_(theta), // copy duplicates
+        rho_bk_(rho), grad_theta_bk_(grad_theta), theta_fw_(theta),
+        rho_fw_(std::move(rho)), // move once after copy
+        grad_theta_fw_(std::move(grad_theta)), theta_select_(std::move(theta)),
+        logp_(logp) {}
+
+  Span(Span<S> &&span1, Span<S> &&span2, Vec<S> &&theta_select, S logp)
+      : theta_bk_(std::move(span1.theta_bk_)),
+        rho_bk_(std::move(span1.rho_bk_)),
+        grad_theta_bk_(std::move(span1.grad_theta_bk_)),
+        theta_fw_(std::move(span2.theta_fw_)),
+        rho_fw_(std::move(span2.rho_fw_)),
+        grad_theta_fw_(std::move(span2.grad_theta_fw_)),
+        theta_select_(std::move(theta_select)), logp_(logp) {}
+};
+
+template <typename S> S log_sum_exp(const S &x1, const S &x2) {
+  using std::fmax, std::log, std::exp;
+  S m = fmax(x1, x2);
+  return m + log(exp(x1 - m) + exp(x2 - m));
+}
+
+template <typename S> S log_sum_exp(const Vec<S> &x) {
+  using std::log;
+  S m = x.maxCoeff();
+  return m + log((x.array() - m).exp().sum());
+}
+
+template <typename S>
+S logp_momentum(const Vec<S> &rho, const Vec<S> &inv_mass) {
+  return -0.5 * rho.dot(inv_mass.cwiseProduct(rho));
+}
+
+template <typename S, typename F>
+bool reversible(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
+		Integer num_steps, S max_error, const Vec<S> &theta,
+		const Vec<S> &rho, const Vec<S> &grad, S logp_next) {
+  if (num_steps < 2) {
+    return true;
+  }
+  // ***HEURISTIC***:  just make sure num_steps /= 2 is not stable
+  S half_step = step;
+  num_steps /= 2;
+  step *= 2;
+  Vec<S> grad_next(grad);
+  Vec<S> theta_next(theta);
+  Vec<S> rho_next(-rho);
+  S logp_min = logp_next;
+  S logp_max = logp_next;
+  for (int n = 0; n < num_steps; ++n) {
+      rho_next.noalias() = rho_next + half_step * grad_next;
+      theta_next.noalias() += step * (inv_mass.array() * rho_next.array()).matrix();
+      logp_grad_fun(theta_next, logp_next, grad_next);
+      rho_next.noalias() += half_step * grad_next;
+      logp_next += logp_momentum(rho_next, inv_mass);
+      logp_min = fmin(logp_min, logp_next);
+      logp_max = fmax(logp_max, logp_next);
+      if (logp_max - logp_min > max_error) {
+	return true;
+      }
+  }
+  std::cout << "non-reversible" << std::endl;
+  return false;
+}  
+
+template <typename S, typename F>
+void macro_step(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
+                const Vec<S> &theta, const Vec<S> &rho, const Vec<S> &grad,
+                Vec<S> &theta_next, Vec<S> &rho_next, Vec<S> &grad_next,
+                S &logp_next, S max_error, bool& irreversible) {
+  using std::fmax, std::fmin;
+  Vec<S> grad_first;
+  S logp_first;
+  logp_grad_fun(theta, logp_first, grad_first);
+  logp_first += logp_momentum(rho, inv_mass);
+  for (int num_steps = 1, halvings = 0; halvings < 10; ++halvings, num_steps *= 2, step *= 0.5) {
+    theta_next = theta;
+    rho_next = rho;
+    grad_next = grad_first;
+    S logp_min = logp_first;
+    S logp_max = logp_first;
+    S half_step = 0.5 * step;
+    for (Integer n = 0; n < num_steps; ++n) {
+      rho_next.noalias() = rho_next + half_step * grad_next;
+      theta_next.noalias() += step * (inv_mass.array() * rho_next.array()).matrix();
+      logp_grad_fun(theta_next, logp_next, grad_next);
+      rho_next.noalias() += half_step * grad_next;
+      logp_next += logp_momentum(rho_next, inv_mass);
+      logp_min = fmin(logp_min, logp_next);
+      logp_max = fmax(logp_max, logp_next);
+      if (logp_max - logp_min > max_error) {
+	break;
+      }
+    }
+    if (logp_max - logp_min <= max_error) {
+      // if (true) return;
+      irreversible = !reversible(logp_grad_fun, inv_mass, step, num_steps,
+				 max_error, theta_next, rho_next, grad_next,
+				 logp_next);
+      return;
+    }
+  }
+  irreversible = true;
+}
+
+template <typename S>
+bool uturn(const Span<S> &span_bk, const Span<S> &span_fw,
+           const Vec<S> &inv_mass) {
+  auto scaled_diff =
+      (inv_mass.array() * (span_fw.theta_fw_ - span_fw.theta_bk_).array())
+          .matrix();
+  return span_fw.rho_fw_.dot(scaled_diff) < 0 ||
+         span_bk.rho_bk_.dot(scaled_diff) < 0;
+}
+
+template <Update U, Direction D, typename S, class Generator>
+Span<S> combine(Random<S, Generator> &rng, Span<S> &&span_old,
+                Span<S> &&span_new, const Vec<S> &inv_mass, bool &uturn_flag) {
+  using std::log;
+  S logp_total = log_sum_exp(span_old.logp_, span_new.logp_);
+  S log_denominator;
+  if constexpr (U == Update::Metropolis) {
+    log_denominator = span_new.logp_;
+  } else { // Update::Barker
+    log_denominator = logp_total;
+  }
+  S update_logprob = span_new.logp_ - log_denominator;
+  bool update = log(rng.uniform_real_01()) < update_logprob;
+  auto &selected = update ? span_new.theta_select_ : span_old.theta_select_;
+  if constexpr (D == Direction::Forward) {
+    uturn_flag = uturn(span_old, span_new, inv_mass);
+    return Span<S>(std::move(span_old), std::move(span_new),
+                   std::move(selected), logp_total);
+  } else { // Direction::Backward
+    uturn_flag = uturn(span_new, span_old, inv_mass);
+    return Span<S>(std::move(span_new), std::move(span_old),
+                   std::move(selected), logp_total);
+  }
+}
+
+template <Direction D, typename S, class F>
+Span<S> build_leaf(const F &logp_grad_fun, const Span<S> &span,
+                   const Vec<S> &inv_mass, S step, S max_error,
+                   bool& reversible) {
+  Vec<S> theta_next;
+  Vec<S> rho_next;
+  Vec<S> grad_theta_next;
+  S logp_theta_next;
+  if constexpr (D == Direction::Forward) {
+    macro_step(logp_grad_fun, inv_mass, step, span.theta_fw_, span.rho_fw_,
+               span.grad_theta_fw_, theta_next, rho_next, grad_theta_next,
+               logp_theta_next, max_error, reversible);
+  } else { // Direction::Backward
+    macro_step(logp_grad_fun, inv_mass, -step, span.theta_bk_, span.rho_bk_,
+               span.grad_theta_bk_, theta_next, rho_next, grad_theta_next,
+               logp_theta_next, max_error, reversible);
+  }
+  return Span<S>(std::move(theta_next), std::move(rho_next),
+                 std::move(grad_theta_next), logp_theta_next);
+}
+
+template <Direction D, typename S, class F, class Generator>
+Span<S> build_span(Random<S, Generator> &rng, const F &logp_grad_fun,
+                   const Vec<S> &inv_mass, S step, Integer depth,
+                   S max_error, const Span<S> &last_span, bool &uturn_flag) {
+  uturn_flag = false;
+  if (depth == 0) {
+    return build_leaf<D>(logp_grad_fun, last_span, inv_mass, step,
+                         max_error, uturn_flag);
+  }
+  if (uturn_flag) {
+    return last_span;  // won't be used
+  }
+  Span<S> span1 = build_span<D>(rng, logp_grad_fun, inv_mass, step,
+                                depth - 1, max_error, last_span, uturn_flag);
+  if (uturn_flag) {
+    return last_span; // won't be used
+  }
+  Span<S> span2 = build_span<D>(rng, logp_grad_fun, inv_mass, step,
+                                depth - 1, max_error, span1, uturn_flag);
+  if (uturn_flag) {
+    return last_span; // won't be used
+  }
+  if constexpr (D == Direction::Forward) {
+    if (uturn(span1, span2, inv_mass)) {
+      uturn_flag = true;
+      return last_span; // won't be used
+    }
+  } else { // Direction::Backward
+    if (uturn(span2, span1, inv_mass)) {
+      uturn_flag = true;
+      return last_span; // won't be used
+    }
+  }
+  return combine<Update::Barker, D>(rng, std::move(span1), std::move(span2),
+                                    inv_mass, uturn_flag);
+}
+
+template <typename S, class F, class Generator>
+Vec<S> transition(Random<S, Generator> &rng, const F &logp_grad_fun,
+                  const Vec<S> &inv_mass, S step, Integer max_depth,
+                  Vec<S> &&theta, S max_error) {
+  Vec<S> rho = rng.standard_normal(theta.size());
+  Vec<S> grad(theta.size());
+  S logp;
+  logp_grad_fun(theta, logp, grad);
+  logp += logp_momentum(rho, inv_mass);
+  Span<S> span_accum(std::move(theta), std::move(rho), std::move(grad), logp);
+  for (Integer depth = 0; depth < max_depth; ++depth) {
+    bool go_forward = rng.uniform_binary();
+    bool uturn_flag;
+    if (go_forward) {
+      Span<S> span_next = build_span<Direction::Forward>(
+          rng, logp_grad_fun, inv_mass, step, depth, max_error, span_accum, uturn_flag);
+      if (uturn_flag)
+        break;
+      span_accum = combine<Update::Metropolis, Direction::Forward>(
+          rng, std::move(span_accum), std::move(span_next), inv_mass,
+          uturn_flag);
+      if (uturn_flag)
+        break;
+    } else {
+      Span<S> span_next = build_span<Direction::Backward>(
+          rng, logp_grad_fun, inv_mass, step, depth, max_error, span_accum, uturn_flag);
+      if (uturn_flag)
+        break;
+      span_accum = combine<Update::Metropolis, Direction::Backward>(
+          rng, std::move(span_accum), std::move(span_next), inv_mass,
+          uturn_flag);
+      if (uturn_flag)
+        break;
+    }
+  }
+  return std::move(span_accum.theta_select_);
+}
+
+template <typename S, class F, class Generator, class H>
+void walnuts(Generator &generator, const F &logp_grad_fun,
+	     const Vec<S> &inv_mass, S step, Integer max_depth, S max_error,
+	     const Vec<S> &theta_init, Integer num_draws, H &handler) {
+  Random<S, Generator> rng{generator};
+  Vec<S> theta = theta_init; // copy once
+  handler(0, theta);
+  for (Integer n = 1; n < num_draws; ++n) {
+    theta = transition(rng, logp_grad_fun, inv_mass, step, max_depth,
+                       std::move(theta), max_error);
+    handler(n, theta);
+  }
+}
+
+template <typename S, class F, class Generator>
+void walnuts(Generator &generator, const F &logp_grad_fun,
+	     const Vec<S> &inv_mass, S step, Integer max_depth, S max_error,
+	     const Vec<S> &theta_init, Matrix<S> &sample) {
+  auto handler = [&sample](Integer n, const Vec<S> &v) { sample.col(n) = v; };
+  walnuts(generator, logp_grad_fun, inv_mass, step, max_depth, max_error,
+	  theta_init, sample.cols(), handler);
+}
+
+} // namespace nuts


### PR DESCRIPTION
This is now down to where WALNUTS does not take any more gradients than NUTS when NUTS uses a stable step size.  It updates `span` to hold the forward log density and reverse log density to avoid recomputing