### PR TITLE
Use std::optional to avoid out parameter for uturns

### DIFF
--- a/walnuts_cpp/include/walnuts/nuts.hpp
+++ b/walnuts_cpp/include/walnuts/nuts.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <optional>
 #include <random>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -103,10 +104,18 @@ void leapfrog(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
 }
 
 template <Direction D, typename S>
+inline auto order_forward_backward(S &&s1, S &&s2) {
+  if constexpr (D == Direction::Forward) {
+    return std::forward_as_tuple(std::forward<S>(s1), std::forward<S>(s2));
+  } else { // Direction::Backward
+    return std::forward_as_tuple(std::forward<S>(s2), std::forward<S>(s1));
+  }
+}
+
+template <Direction D, typename S>
 inline bool uturn(const Span<S> &span_1, const Span<S> &span_2,
                   const Vec<S> &inv_mass) {
-  auto &&span_bk = (D == Direction::Forward) ? span_1 : span_2;
-  auto &&span_fw = (D == Direction::Forward) ? span_2 : span_1;
+  auto &&[span_bk, span_fw] = order_forward_backward<D>(span_1, span_2);
   auto scaled_diff =
       (inv_mass.array() * (span_fw.theta_fw_ - span_fw.theta_bk_).array())
           .matrix();
@@ -119,6 +128,15 @@ std::conditional_t<R == CombineResult::ThrowAway, std::optional<Span<S>>,
                    std::pair<Span<S>, bool>>
 combine(Random<S, Generator> &rng, Span<S> &&span_old, Span<S> &&span_new,
         const Vec<S> &inv_mass) {
+
+  bool did_uturn = uturn<D>(span_old, span_new, inv_mass);
+
+  if constexpr (R == CombineResult::ThrowAway) {
+    if (did_uturn) {
+      return std::nullopt;
+    }
+  }
+
   using std::log;
   S logp_total = log_sum_exp(span_old.logp_, span_new.logp_);
   S log_denominator;
@@ -131,23 +149,10 @@ combine(Random<S, Generator> &rng, Span<S> &&span_old, Span<S> &&span_new,
   bool update = log(rng.uniform_real_01()) < update_logprob;
   auto &selected = update ? span_new.theta_select_ : span_old.theta_select_;
 
-  bool did_uturn = uturn<D>(span_old, span_new, inv_mass);
+  auto &&[span_bk, span_fw] = order_forward_backward<D>(span_old, span_new);
 
-  if constexpr (R == CombineResult::ThrowAway) {
-    if (did_uturn) {
-      return std::nullopt;
-    }
-  }
-
-  Span<S> next = [&]() {
-    if constexpr (D == Direction::Forward) {
-      return Span<S>(std::move(span_old), std::move(span_new),
-                     std::move(selected), logp_total);
-    } else { // Direction::Backward
-      return Span<S>(std::move(span_new), std::move(span_old),
-                     std::move(selected), logp_total);
-    }
-  }();
+  Span<S> next(std::move(span_bk), std::move(span_fw), std::move(selected),
+               logp_total);
 
   if constexpr (R == CombineResult::ThrowAway) {
     return std::make_optional<Span<S>>(std::move(next));

--- a/walnuts_cpp/include/walnuts/nuts.hpp
+++ b/walnuts_cpp/include/walnuts/nuts.hpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <random>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 
 namespace nuts {
@@ -20,8 +19,6 @@ using Integer = std::int32_t;
 enum class Update { Barker, Metropolis };
 
 enum class Direction { Backward, Forward };
-
-enum class CombineResult { Keep, ThrowAway };
 
 template <typename S, class Generator> class Random {
 public:
@@ -123,20 +120,9 @@ inline bool uturn(const Span<S> &span_1, const Span<S> &span_2,
          span_bk.rho_bk_.dot(scaled_diff) < 0;
 }
 
-template <Update U, Direction D, CombineResult R, typename S, class Generator>
-std::conditional_t<R == CombineResult::ThrowAway, std::optional<Span<S>>,
-                   std::pair<Span<S>, bool>>
-combine(Random<S, Generator> &rng, Span<S> &&span_old, Span<S> &&span_new,
-        const Vec<S> &inv_mass) {
-
-  bool did_uturn = uturn<D>(span_old, span_new, inv_mass);
-
-  if constexpr (R == CombineResult::ThrowAway) {
-    if (did_uturn) {
-      return std::nullopt;
-    }
-  }
-
+template <Update U, Direction D, typename S, class Generator>
+Span<S> combine(Random<S, Generator> &rng, Span<S> &&span_old,
+                Span<S> &&span_new) {
   using std::log;
   S logp_total = log_sum_exp(span_old.logp_, span_new.logp_);
   S log_denominator;
@@ -150,15 +136,8 @@ combine(Random<S, Generator> &rng, Span<S> &&span_old, Span<S> &&span_new,
   auto &selected = update ? span_new.theta_select_ : span_old.theta_select_;
 
   auto &&[span_bk, span_fw] = order_forward_backward<D>(span_old, span_new);
-
-  Span<S> next(std::move(span_bk), std::move(span_fw), std::move(selected),
-               logp_total);
-
-  if constexpr (R == CombineResult::ThrowAway) {
-    return std::make_optional<Span<S>>(std::move(next));
-  } else {
-    return std::make_pair(std::move(next), did_uturn);
-  }
+  return Span<S>(std::move(span_bk), std::move(span_fw), std::move(selected),
+                 logp_total);
 }
 
 template <Direction D, typename S, class F>
@@ -205,8 +184,7 @@ std::optional<Span<S>> build_span(Random<S, Generator> &rng,
     return std::nullopt;
   }
 
-  return combine<Update::Barker, D, CombineResult::ThrowAway>(
-      rng, *std::move(span1), *std::move(span2), inv_mass);
+  return combine<Update::Barker, D>(rng, *std::move(span1), *std::move(span2));
 }
 
 template <typename S, class F, class Generator>
@@ -223,26 +201,32 @@ Vec<S> transition(Random<S, Generator> &rng, const F &logp_grad_fun,
     bool go_forward = rng.uniform_binary();
     bool uturn_flag;
     if (go_forward) {
-      auto span_next = build_span<Direction::Forward>(
-          rng, logp_grad_fun, inv_mass, step, depth, span_accum);
+      constexpr Direction D = Direction::Forward;
+
+      auto span_next =
+          build_span<D>(rng, logp_grad_fun, inv_mass, step, depth, span_accum);
       if (!span_next)
         break;
 
-      std::tie(span_accum, uturn_flag) =
-          combine<Update::Metropolis, Direction::Forward, CombineResult::Keep>(
-              rng, std::move(span_accum), *std::move(span_next), inv_mass);
+      uturn_flag = uturn<D>(span_accum, *span_next, inv_mass);
+
+      span_accum = combine<Update::Metropolis, D>(rng, std::move(span_accum),
+                                                  *std::move(span_next));
 
       if (uturn_flag)
         break;
     } else {
-      auto span_next = build_span<Direction::Backward>(
-          rng, logp_grad_fun, inv_mass, step, depth, span_accum);
+      constexpr Direction D = Direction::Backward;
+
+      auto span_next =
+          build_span<D>(rng, logp_grad_fun, inv_mass, step, depth, span_accum);
       if (!span_next)
         break;
 
-      std::tie(span_accum, uturn_flag) =
-          combine<Update::Metropolis, Direction::Backward, CombineResult::Keep>(
-              rng, std::move(span_accum), *std::move(span_next), inv_mass);
+      uturn_flag = uturn<D>(span_accum, *span_next, inv_mass);
+
+      span_accum = combine<Update::Metropolis, D>(rng, std::move(span_accum),
+                                                  *std::move(span_next));
 
       if (uturn_flag)
         break;

--- a/walnuts_cpp/include/walnuts/walnuts.hpp
+++ b/walnuts_cpp/include/walnuts/walnuts.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <optional>
 #include <random>
+#include <type_traits>
 #include <utility>
 
 namespace walnuts {

--- a/walnuts_cpp/include/walnuts/walnuts.hpp
+++ b/walnuts_cpp/include/walnuts/walnuts.hpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <iostream>
+#include <optional>
 #include <random>
 #include <utility>
 
@@ -18,6 +18,8 @@ using Integer = std::int32_t;
 enum class Update { Barker, Metropolis };
 
 enum class Direction { Backward, Forward };
+
+enum class CombineResult { Keep, ThrowAway };
 
 template <typename S, class Generator> class Random {
 public:
@@ -87,7 +89,7 @@ template <typename S>
 S logp_momentum(const Vec<S> &rho, const Vec<S> &inv_mass) {
   return -0.5 * rho.dot(inv_mass.cwiseProduct(rho));
 }
-    
+
 template <typename S, typename F>
 bool within_tolerance(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
 		      Integer num_steps, S max_error, Vec<S> &theta_next,
@@ -136,9 +138,9 @@ bool reversible(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
 }
 
 template <Direction D, typename S, typename F>
-void macro_step(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
-                const Span<S>& span, Vec<S> &theta_next, Vec<S> &rho_next, Vec<S> &grad_next,
-                S &logp_next, S max_error, bool& irreversible) {
+bool macro_step(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
+                const Span<S> &span, Vec<S> &theta_next, Vec<S> &rho_next,
+                Vec<S> &grad_next, S &logp_next, S max_error) {
   constexpr bool is_forward = (D == Direction::Forward);
   const Vec<S>& theta =  is_forward ? span.theta_fw_ : span.theta_bk_;
   const Vec<S>& rho = is_forward ? span.rho_fw_ : span.rho_bk_;
@@ -163,13 +165,11 @@ void macro_step(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
       logp_max = fmax(logp_max, logp_next);
     }
     if (logp_max - logp_min <= max_error) {
-      irreversible = !reversible(logp_grad_fun, inv_mass, step, num_steps,
-				 max_error, theta_next, rho_next, grad_next,
-				 logp_next);
-      return;
+      return !reversible(logp_grad_fun, inv_mass, step, num_steps, max_error,
+                         theta_next, rho_next, grad_next, logp_next);
     }
   }
-  irreversible = true;
+  return true;
 }
 
 template <Direction D, typename S>
@@ -184,67 +184,88 @@ inline bool uturn(const Span<S> &span_1, const Span<S> &span_2,
          span_bk.rho_bk_.dot(scaled_diff) < 0;
 }
 
-template <Update U, Direction D, typename S, class Generator>
-Span<S> combine(Random<S, Generator> &rng, Span<S> &&span_old,
-                Span<S> &&span_new, const Vec<S> &inv_mass, bool &uturn_flag) {
+template <Update U, Direction D, CombineResult R, typename S, class Generator>
+std::conditional_t<R == CombineResult::ThrowAway, std::optional<Span<S>>,
+                   std::pair<Span<S>, bool>>
+combine(Random<S, Generator> &rng, Span<S> &&span_old, Span<S> &&span_new,
+        const Vec<S> &inv_mass) {
   using std::log;
   S logp_total = log_sum_exp(span_old.logp_, span_new.logp_);
-  S log_denominator = (U == Update::Metropolis) ? span_new.logp_ : logp_total;
+  S log_denominator;
+  if constexpr (U == Update::Metropolis) {
+    log_denominator = span_new.logp_;
+  } else { // Update::Barker
+    log_denominator = logp_total;
+  }
   S update_logprob = span_new.logp_ - log_denominator;
   bool update = log(rng.uniform_real_01()) < update_logprob;
   auto &selected = update ? span_new.theta_select_ : span_old.theta_select_;
-  uturn_flag = uturn<D>(span_old, span_new, inv_mass);
-  if constexpr (D == Direction::Forward) {
-    return Span<S>(std::move(span_old), std::move(span_new),
-                   std::move(selected), logp_total);
-  } else { // Direction::Backward
-    return Span<S>(std::move(span_new), std::move(span_old),
-                   std::move(selected), logp_total);
+
+  bool did_uturn = uturn<D>(span_old, span_new, inv_mass);
+
+  if constexpr (R == CombineResult::ThrowAway) {
+    if (did_uturn) {
+      return std::nullopt;
+    }
+  }
+
+  Span<S> next = [&]() {
+    if constexpr (D == Direction::Forward) {
+      return Span<S>(std::move(span_old), std::move(span_new),
+                     std::move(selected), logp_total);
+    } else { // Direction::Backward
+      return Span<S>(std::move(span_new), std::move(span_old),
+                     std::move(selected), logp_total);
+    }
+  }();
+
+  if constexpr (R == CombineResult::ThrowAway) {
+    return std::make_optional<Span<S>>(std::move(next));
+  } else {
+    return std::make_pair(std::move(next), did_uturn);
   }
 }
 
 template <Direction D, typename S, class F>
-Span<S> build_leaf(const F &logp_grad_fun, const Span<S> &span,
-                   const Vec<S> &inv_mass, S step, S max_error,
-                   bool& reversible) {
+std::optional<Span<S>> build_leaf(const F &logp_grad_fun, const Span<S> &span,
+                                  const Vec<S> &inv_mass, S step, S max_error) {
   Vec<S> theta_next;
   Vec<S> rho_next;
   Vec<S> grad_theta_next;
   S logp_theta_next;
-  macro_step<D>(logp_grad_fun, inv_mass, step, span, theta_next, rho_next,
-        grad_theta_next, logp_theta_next, max_error, reversible);
+  if (macro_step<D>(logp_grad_fun, inv_mass, step, span, theta_next, rho_next,
+                    grad_theta_next, logp_theta_next, max_error))
+    return std::nullopt;
   return Span<S>(std::move(theta_next), std::move(rho_next),
                  std::move(grad_theta_next), logp_theta_next);
 }
 
 template <Direction D, typename S, class F, class Generator>
-Span<S> build_span(Random<S, Generator> &rng, const F &logp_grad_fun,
-                   const Vec<S> &inv_mass, S step, Integer depth,
-                   S max_error, const Span<S> &last_span, bool &uturn_flag) {
-  uturn_flag = false;
+std::optional<Span<S>> build_span(Random<S, Generator> &rng,
+                                  const F &logp_grad_fun,
+                                  const Vec<S> &inv_mass, S step, Integer depth,
+                                  S max_error, const Span<S> &last_span) {
   if (depth == 0) {
-    return build_leaf<D>(logp_grad_fun, last_span, inv_mass, step,
-                         max_error, uturn_flag);
+    return build_leaf<D>(logp_grad_fun, last_span, inv_mass, step, max_error);
   }
-  if (uturn_flag) {
-    return last_span;  // won't be used
+  auto span1 = build_span<D>(rng, logp_grad_fun, inv_mass, step, depth - 1,
+                             max_error, last_span);
+  if (!span1) {
+    return std::nullopt;
   }
-  Span<S> span1 = build_span<D>(rng, logp_grad_fun, inv_mass, step,
-                                depth - 1, max_error, last_span, uturn_flag);
-  if (uturn_flag) {
-    return last_span; // won't be used
+
+  auto span2 = build_span<D>(rng, logp_grad_fun, inv_mass, step, depth - 1,
+                             max_error, *span1);
+  if (!span2) {
+    return std::nullopt;
   }
-  Span<S> span2 = build_span<D>(rng, logp_grad_fun, inv_mass, step,
-                                depth - 1, max_error, span1, uturn_flag);
-  if (uturn_flag) {
-    return last_span; // won't be used
+
+  if (uturn<D>(*span1, *span2, inv_mass)) {
+    return std::nullopt;
   }
-  uturn_flag = uturn<D>(span1, span2, inv_mass);
-  if (uturn_flag) {
-    return last_span; // won't be used
-  }
-  return combine<Update::Barker, D>(rng, std::move(span1), std::move(span2),
-                                    inv_mass, uturn_flag);
+
+  return combine<Update::Barker, D, CombineResult::ThrowAway>(
+      rng, *std::move(span1), *std::move(span2), inv_mass);
 }
 
 template <typename S, class F, class Generator>
@@ -261,23 +282,27 @@ Vec<S> transition(Random<S, Generator> &rng, const F &logp_grad_fun,
     const bool go_forward = rng.uniform_binary();
     bool uturn_flag;
     if (go_forward) {
-      Span<S> span_next = build_span<Direction::Forward>(
-          rng, logp_grad_fun, inv_mass, step, depth, max_error, span_accum, uturn_flag);
-      if (uturn_flag)
+      auto span_next = build_span<Direction::Forward>(
+          rng, logp_grad_fun, inv_mass, step, depth, max_error, span_accum);
+      if (!span_next)
         break;
-      span_accum = combine<Update::Metropolis, Direction::Forward>(
-          rng, std::move(span_accum), std::move(span_next), inv_mass,
-          uturn_flag);
+
+      std::tie(span_accum, uturn_flag) =
+          combine<Update::Metropolis, Direction::Forward, CombineResult::Keep>(
+              rng, std::move(span_accum), *std::move(span_next), inv_mass);
+
       if (uturn_flag)
         break;
     } else {
-      Span<S> span_next = build_span<Direction::Backward>(
-          rng, logp_grad_fun, inv_mass, step, depth, max_error, span_accum, uturn_flag);
-      if (uturn_flag)
+      auto span_next = build_span<Direction::Backward>(
+          rng, logp_grad_fun, inv_mass, step, depth, max_error, span_accum);
+      if (!span_next)
         break;
-      span_accum = combine<Update::Metropolis, Direction::Backward>(
-          rng, std::move(span_accum), std::move(span_next), inv_mass,
-          uturn_flag);
+
+      std::tie(span_accum, uturn_flag) =
+          combine<Update::Metropolis, Direction::Backward, CombineResult::Keep>(
+              rng, std::move(span_accum), *std::move(span_next), inv_mass);
+
       if (uturn_flag)
         break;
     }
@@ -308,4 +333,4 @@ void walnuts(Generator &generator, const F &logp_grad_fun,
 	  theta_init, sample.cols(), handler);
 }
 
-} // namespace nuts
+} // namespace walnuts


### PR DESCRIPTION
This avoids the 'unused' returns by returning nullopt instead.

There is no performance difference.

The only nonstandard part is that `combine` now takes an extra tparam which determines whether we materialize the new span in the case of a u-turn