### PR TITLE
Online variance

### DIFF
--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 file(GLOB_RECURSE ALL_SOURCE_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/examples/*.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp"
 )
 
 find_program(CLANG_FORMAT_BIN clang-format)

--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -75,7 +75,7 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extras/CMakeLists.txt")
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/extras")
 endif()
 
-if (WALNUTS_BUILD_TESTS) 
+if (WALNUTS_BUILD_TESTS)
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
 endif()
 

--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -75,6 +75,9 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extras/CMakeLists.txt")
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/extras")
 endif()
 
+##########################
+##       Tests         ##
+##########################
 if (WALNUTS_BUILD_TESTS)
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
 endif()

--- a/walnuts_cpp/README.md
+++ b/walnuts_cpp/README.md
@@ -175,6 +175,6 @@ make format
 The formatting style is defined in the file
 `walnuts_cpp/.clang_format`.  It specifies
 
-* Google format for compactness
-* braces and newlines around conditional and loop bodies
-* include ordering sorted within block, but blocks maintained
+* Google format for compactness,
+* braces and newlines around conditional and loop bodies, and
+* include ordering sorted within block, but blocks maintained.

--- a/walnuts_cpp/README.md
+++ b/walnuts_cpp/README.md
@@ -81,7 +81,7 @@ Running the following from `walnuts_cpp` will run all tests in the `tests` direc
 
 ```bash
 cmake -S . -B "build" -DCMAKE_BUILD_TYPE=RELEASE
-cmake --build build --parallel 3 --target mock_test
+cmake --build build --parallel 3 --target mock_test welford_test
 ctest --test-dir ./build/tests
 ```
 

--- a/walnuts_cpp/README.md
+++ b/walnuts_cpp/README.md
@@ -16,7 +16,9 @@ Alternatively `cmake` may be used to build the examples and tests.
 
 ```bash
 # /usr/bin/bash
-# Assumes you start in walnuts_cpp directory
+
+# Start in walnuts_cpp directory
+cd walnuts_cpp
 
 # Run cmake with
 # The source directory as our current directory (-S .)

--- a/walnuts_cpp/README.md
+++ b/walnuts_cpp/README.md
@@ -12,7 +12,7 @@ clang++ -std=c++17 -O3 -I lib/eigen-3.4.0 -I ./include ./examples/test.cpp -o te
 ./test
 ```
 
-Alternatively you can use the cmake setup.
+Alternatively `cmake` may be used to build the examples and tests.
 
 ```bash
 # /usr/bin/bash
@@ -45,12 +45,32 @@ make -j3 test_nuts
 
 ## Structure
 
+The project directory structure is as follows.  The `...` indicate
+elided subdirectories.  The `build` directories are generated
+automatically and the `lib` directory contains external includes, only
+the top-level names of which are listed.
+
+
 ```bash
-walnuts_cpp
-├── examples # Test Examples
-├── extras # Folder for optional dev tools
-├── include # Headers for the library
+.
+├── build...
+├── examples
+│   ├── test_stan.cpp
+│   └── test.cpp
+├── extras
+│   └── readme.md
+├── include
 │   └── walnuts
+│       ├── nuts.hpp
+│       ├── util.hpp
+│       └── walnuts.hpp
+├── lib
+│   ├── eigen-3.4.0...
+├── tests
+│   ├── CMakeLists.txt
+│   └── mock_test.cpp
+├── CMakeLists.txt
+└── README.md
 ```
 
 ## Running Tests

--- a/walnuts_cpp/README.md
+++ b/walnuts_cpp/README.md
@@ -71,6 +71,7 @@ the top-level names of which are listed.
 ├── tests
 │   ├── CMakeLists.txt
 │   └── mock_test.cpp
+│   └── welford_test.cpp
 ├── CMakeLists.txt
 └── README.md
 ```
@@ -156,11 +157,13 @@ This is nice for refreshing variables with `cmake .. --fresh`
 Setting `-DCMAKE_BUILD_TYPE=DEBUG` will make the make file generation verbose.
 For all other build types you can add `VERBOSE=1` to your make call to see a trace of the actions CMake performs.
 
-## Formatting
+## Automatic formatting
 
-After running the build process (see above), all of the `.hpp` files
-in the `include` directory and all of the `.cpp` files in the
-`examples` directory will be formatted.
+The following commands will use `clang-format` to automaticlaly format
+
+* `.hpp` files in `include`,
+* `.cpp` files in `examples`, and
+* `.cpp` files in `tests`.
 
 ```bash
 # /usr/bin/bash
@@ -175,6 +178,6 @@ make format
 The formatting style is defined in the file
 `walnuts_cpp/.clang_format`.  It specifies
 
-* Google format for compactness,
+* baseline Google format for compactness,
 * braces and newlines around conditional and loop bodies, and
 * include ordering sorted within block, but blocks maintained.

--- a/walnuts_cpp/examples/test-welford.cpp
+++ b/walnuts_cpp/examples/test-welford.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <walnuts/welford.hpp>
+
+using S = double;
+using Vec = Eigen::Matrix<S, Eigen::Dynamic, 1>;
+using walnuts::DiscountedOnlineMoments;
+
+void report(const std::string& label, const DiscountedOnlineMoments<S>& dom) {
+  std::cout << label << std::endl;
+  std::cout << "Mean: " << dom.mean().transpose() << std::endl;
+  std::cout << "Variance: " << dom.variance().transpose().eval() << std::endl;
+}
+
+int main() {
+  constexpr S alpha = 0.9;
+  constexpr int dim = 2;
+  DiscountedOnlineMoments<S> dom(alpha, dim);
+  Vec x(dim);
+
+  report("\nZero observations:", dom);
+
+  x << 1.0, 2.0;
+  dom.update(x);
+  report("\nOne observation y[1] = [1 2]:", dom);
+
+  for (S i = 1; i <= 10; ++i) {
+    x << i, 2 * i;
+    dom.update(x);
+  }
+  report("\nTen observations ([1 2], [2, 4], ..., [10 20]):", dom);
+
+  return 0;
+}

--- a/walnuts_cpp/include/walnuts/welford.hpp
+++ b/walnuts_cpp/include/walnuts/welford.hpp
@@ -85,7 +85,9 @@ class DiscountedOnlineMoments {
    * @return The variance estimate.
    */
   Vec variance() const {
-    if (weight_ > 0) return s_ / weight_;
+    if (weight_ > 0) {
+      return s_ / weight_;
+    }
     return Vec::Zero(mu_.size());
   }
 

--- a/walnuts_cpp/include/walnuts/welford.hpp
+++ b/walnuts_cpp/include/walnuts/welford.hpp
@@ -1,0 +1,99 @@
+#ifndef WALNUTS_WELFORD_HPP
+#define WALNUTS_WELFORD_HPP
+
+#include <Eigen/Dense>
+
+namespace walnuts {
+
+/**
+ * The `DiscountedOnlineMoments` has an `update()` method that
+ * receives vectors and updates its constant internal memory in order
+ * to provide estimates of means and variances at any point.  The past
+ * is optionally discounted to upweight more recent observations.
+ *
+ * In addition to the discount factor `alpha`, the algorithm maintains
+ * a scalar `weight` and two vectors, `mu` and `s`, which store the
+ * sufficient statistics required to estimate mean and variance.
+ * The initialization is all zeros,
+ *
+ * ```
+ * weight = 0;  mu = 0;  s = 0
+ * ```
+ *
+ * Updates for a new observation y are given by
+ *
+ * ```
+ * diff = y - mu_;
+ * weight_ = alpha * weight + 1
+ * mu_ = mu + delta / weight
+ * s = alpha * s + delta * (y - mu)
+ * ```
+ *
+ * At any given point in time, the current estimates of mean and
+ * variance are given by
+ *
+ * ```
+ * mean = mu
+ * variance = s / weight
+ * ```
+ *
+ * @tparam S The type of scalars.
+ */
+template <typename S>
+class DiscountedOnlineMoments {
+ public:
+  /**
+   * The type of vectors with scalar type `S`.
+   */
+  using Vec = Eigen::Matrix<S, Eigen::Dynamic, 1>;
+
+  /**
+   * Construct an online estimator of moments of the given dimensionality that
+   * discounts the past by a factor of `alpha in (0, 1]` before each
+   * observation.  Setting `alpha` to 1 does no discounting.
+   *
+   * @param alpha The discount factor.
+   * @param dim Number of dimensions in observation vectors.
+   */
+  DiscountedOnlineMoments(S alpha, int dim)
+      : alpha_(alpha), weight_(0), mu_(Vec::Zero(dim)), s_(Vec::Zero(dim)) {}
+
+  /**
+   * Update the state of this accumulator by observing the specified vector.
+   *
+   * @param y An observation vector.
+   */
+  void update(const Vec& y) {
+    const Vec delta = y - mu_;
+    weight_ = alpha_ * weight_ + 1;
+    mu_ += delta / weight_;
+    s_ = alpha_ * s_ + delta.cwiseProduct(y - mu_);
+  }
+
+  /**
+   * Return the estimate of the mean.
+   *
+   * @return The mean estimate.
+   */
+  const Vec& mean() const { return mu_; }
+
+  /**
+   * Return the estimate of the variance.
+   *
+   * @return The variance estimate.
+   */
+  Vec variance() const {
+    if (weight_ > 0) return s_ / weight_;
+    return Vec::Zero(mu_.size());
+  }
+
+ private:
+  S alpha_;
+  S weight_;
+  Vec mu_;
+  Vec s_;
+};
+
+}  // namespace walnuts
+
+#endif  // WALNUTS_WELFORD_HPP

--- a/walnuts_cpp/tests/CMakeLists.txt
+++ b/walnuts_cpp/tests/CMakeLists.txt
@@ -14,3 +14,10 @@ target_link_libraries(mock_test
   Eigen3::Eigen
   nuts::nuts)
 add_test(NAME mock_test COMMAND mock_test)
+
+add_executable(welford_test welford_test.cpp)
+target_link_libraries(welford_test
+  gtest_main
+  Eigen3::Eigen
+  nuts::nuts)
+add_test(NAME welford_test COMMAND welford_test)

--- a/walnuts_cpp/tests/mock_test.cpp
+++ b/walnuts_cpp/tests/mock_test.cpp
@@ -1,10 +1,8 @@
-#include <walnuts/walnuts.hpp>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cmath>
 #include <iostream>
 #include <random>
+#include <walnuts/walnuts.hpp>
 
-TEST(Walnuts, basic_test) {
-  EXPECT_TRUE(true);
-}
+TEST(Walnuts, basic_test) { EXPECT_TRUE(true); }

--- a/walnuts_cpp/tests/welford_test.cpp
+++ b/walnuts_cpp/tests/welford_test.cpp
@@ -4,8 +4,8 @@
 #include <random>
 #include <vector>
 
-#include <Eigen/Dense>
 #include <gtest/gtest.h>
+#include <Eigen/Dense>
 
 #include <walnuts/welford.hpp>
 
@@ -94,7 +94,8 @@ TEST(Welford, test_no_discounting) {
 
   Eigen::VectorXd sum_sq_diffs = Eigen::VectorXd::Zero(D);
   for (auto y : ys) {
-    sum_sq_diffs += ((y - mean_expected).array() * (y - mean_expected).array()).matrix();
+    sum_sq_diffs +=
+        ((y - mean_expected).array() * (y - mean_expected).array()).matrix();
   }
   Eigen::VectorXd variance_expected = sum_sq_diffs / N;
 

--- a/walnuts_cpp/tests/welford_test.cpp
+++ b/walnuts_cpp/tests/welford_test.cpp
@@ -1,0 +1,140 @@
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include <walnuts/welford.hpp>
+
+Eigen::VectorXd discounted_mean(const std::vector<Eigen::VectorXd>& ys,
+                                double alpha) {
+  int N = ys.size();
+  int D = ys[0].size();
+  double weight_sum = 0;
+  Eigen::VectorXd weighted_value_sum = Eigen::VectorXd::Zero(D);
+  for (int n = 0; n < N; ++n) {
+    double weight = std::pow(alpha, N - n - 1);
+    weight_sum += weight;
+    weighted_value_sum += weight * ys[n];
+  }
+  return weighted_value_sum / weight_sum;
+}
+
+Eigen::VectorXd discounted_variance(const std::vector<Eigen::VectorXd>& ys,
+                                    double alpha) {
+  Eigen::VectorXd mu = discounted_mean(ys, alpha);
+  int N = ys.size();
+  int D = ys[0].size();
+  double weight_sum = 0;
+  Eigen::VectorXd weighted_sq_diff_sum = Eigen::VectorXd::Zero(D);
+  for (int n = 0; n < N; ++n) {
+    double weight = std::pow(alpha, N - n - 1);
+    weight_sum += weight;
+    auto diff = (ys[n] - mu).array();
+    weighted_sq_diff_sum += weight * (diff * diff).matrix();
+  }
+  return weighted_sq_diff_sum / weight_sum;
+}
+
+TEST(Welford, test_zero_observations) {
+  double alpha = 0.95;
+  int dim = 2;
+  nuts::DiscountedOnlineMoments<double> acc(alpha, dim);
+
+  Eigen::VectorXd m = acc.mean();
+  Eigen::VectorXd v = acc.variance();
+  EXPECT_EQ(2, m.size());
+  EXPECT_FLOAT_EQ(0.0, m(0));
+  EXPECT_FLOAT_EQ(0.0, m(1));
+  EXPECT_EQ(2, v.size());
+  EXPECT_FLOAT_EQ(0.0, v(0));
+  EXPECT_FLOAT_EQ(0.0, v(1));
+}
+
+TEST(Welford, test_one_observation) {
+  double alpha = 0.95;
+  int dim = 2;
+  nuts::DiscountedOnlineMoments<double> acc(alpha, dim);
+
+  Eigen::VectorXd y(2);
+  y << 0.2, -1.3;
+  acc.update(y);
+
+  Eigen::VectorXd m = acc.mean();
+  Eigen::VectorXd v = acc.variance();
+
+  EXPECT_EQ(2, m.size());
+  EXPECT_FLOAT_EQ(0.2, m(0));
+  EXPECT_FLOAT_EQ(-1.3, m(1));
+  EXPECT_EQ(2, v.size());
+  EXPECT_FLOAT_EQ(0.0, v(0));
+  EXPECT_FLOAT_EQ(0.0, v(1));
+}
+
+TEST(Welford, test_no_discounting) {
+  int D = 2;
+  int N = 100;
+  std::vector<Eigen::VectorXd> ys(N);
+  for (int n = 0; n < N; ++n) {
+    ys[n] = Eigen::VectorXd::Zero(D);
+  }
+  for (int n = 0; n < N; ++n) {
+    double x = static_cast<double>(n);
+    ys[n] << x, std::sqrt(x);
+  }
+
+  Eigen::VectorXd sum = Eigen::VectorXd::Zero(D);
+  for (auto y : ys) {
+    sum += y;
+  }
+  Eigen::VectorXd mean_expected = sum / N;
+
+  Eigen::VectorXd sum_sq_diffs = Eigen::VectorXd::Zero(D);
+  for (auto y : ys) {
+    sum_sq_diffs += ((y - mean_expected).array() * (y - mean_expected).array()).matrix();
+  }
+  Eigen::VectorXd variance_expected = sum_sq_diffs / N;
+
+  double alpha = 1.0;
+  nuts::DiscountedOnlineMoments<double> acc(alpha, D);
+
+  for (int n = 0; n < N; ++n) {
+    acc.update(ys[n]);
+  }
+  Eigen::VectorXd m = acc.mean();
+  Eigen::VectorXd v = acc.variance();
+
+  EXPECT_TRUE(m.isApprox(mean_expected, 1e-8));
+  EXPECT_TRUE(v.isApprox(variance_expected, 1e-8));
+}
+
+TEST(Welford, test_ten_observations) {
+  int D = 3;
+  int N = 10;
+  std::vector<Eigen::VectorXd> ys(N);
+  for (int n = 0; n < N; ++n) {
+    ys[n] = Eigen::VectorXd::Zero(D);
+  }
+  for (int n = 0; n < N; ++n) {
+    double x = static_cast<double>(n);
+    ys[n] << x, x * x, std::exp(x);
+  }
+
+  double alpha = 0.95;
+  nuts::DiscountedOnlineMoments<double> acc(alpha, D);
+
+  for (int n = 0; n < N; ++n) {
+    acc.update(ys[n]);
+  }
+  Eigen::VectorXd m = acc.mean();
+  Eigen::VectorXd v = acc.variance();
+
+  Eigen::VectorXd mean_expected = discounted_mean(ys, alpha);
+  EXPECT_TRUE(m.isApprox(mean_expected, 1e-8));
+
+  Eigen::VectorXd variance_expected = discounted_variance(ys, alpha);
+  EXPECT_TRUE(v.isApprox(variance_expected, 1e-8));
+}


### PR DESCRIPTION
I added a discounted Welford accumulator which will be required for mass matrix adaptation.  The master plan is to try something like Nutpie, but with continuous mass matrix estimate updates with discounts rather than buffering and updating.

I added doc for this one.  

There is probably a way to simplify the cut-and-paste I used (and @SteveBronder helped with) in the cmake.