### PR TITLE
mass for momentum refresh

### DIFF
--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -67,7 +67,6 @@ if (WALNUTS_BUILD_EXAMPLES)
   target_compile_options(test_nuts PRIVATE -O3 -Wall)
 endif()
 
-
 ##########################
 ##       Extras         ##
 ##########################


### PR DESCRIPTION
This is fixing a bug where I forgot to include the covariance for the mass matrix refresh.  This fixes it by creeating the Cholesky factor of the mass matrix in the top-level NUTS call, then passing it to the transition function.