### PR TITLE
shared utils, nuts namespace

### DIFF
--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -40,7 +40,7 @@ void test_nuts(const VectorS& theta_init, G& generator, int D, int N,
 
   auto global_start = std::chrono::high_resolution_clock::now();
   if constexpr (U == Sampler::Walnuts) {
-    walnuts::walnuts(generator, standard_normal_logp_grad<S>, inv_mass,
+    nuts::walnuts(generator, standard_normal_logp_grad<S>, inv_mass,
                      step_size, max_depth, max_error, theta_init, draws);
   } else if constexpr (U == Sampler::Nuts) {
     nuts::nuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,

--- a/walnuts_cpp/include/walnuts/nuts.hpp
+++ b/walnuts_cpp/include/walnuts/nuts.hpp
@@ -1,4 +1,3 @@
-#include <Eigen/Dense>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -7,40 +6,11 @@
 #include <tuple>
 #include <utility>
 
+#include <Eigen/Dense>
+
+#include "util.hpp"
+
 namespace nuts {
-
-template <typename S>
-using Vec = Eigen::Matrix<S, Eigen::Dynamic, 1>;
-
-template <typename S>
-using Matrix = Eigen::Matrix<S, Eigen::Dynamic, Eigen::Dynamic>;
-
-using Integer = std::int32_t;
-
-enum class Update { Barker, Metropolis };
-
-enum class Direction { Backward, Forward };
-
-template <typename S, class Generator>
-class Random {
- public:
-  explicit Random(Generator &rng)
-      : rng_(rng), unif_(0.0, 1.0), binary_(0.5), normal_(0.0, 1.0) {}
-
-  inline S uniform_real_01() { return unif_(rng_); }
-
-  inline bool uniform_binary() { return binary_(rng_); }
-
-  inline Vec<S> standard_normal(Integer n) {
-    return Vec<S>::NullaryExpr(n, [&](Integer) { return normal_(rng_); });
-  }
-
- private:
-  Generator &rng_;
-  std::uniform_real_distribution<S> unif_;
-  std::bernoulli_distribution binary_;
-  std::normal_distribution<S> normal_;
-};
 
 template <typename S>
 class Span {
@@ -75,25 +45,6 @@ class Span {
   S logp_;
 };
 
-template <typename S>
-S log_sum_exp(const S &x1, const S &x2) {
-  using std::fmax, std::log, std::exp;
-  S m = fmax(x1, x2);
-  return m + log(exp(x1 - m) + exp(x2 - m));
-}
-
-template <typename S>
-S log_sum_exp(const Vec<S> &x) {
-  using std::log;
-  S m = x.maxCoeff();
-  return m + log((x.array() - m).exp().sum());
-}
-
-template <typename S>
-S logp_momentum(const Vec<S> &rho, const Vec<S> &inv_mass) {
-  return -0.5 * rho.dot(inv_mass.cwiseProduct(rho));
-}
-
 template <typename S, typename F>
 void leapfrog(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
               const Vec<S> &theta, const Vec<S> &rho, const Vec<S> &grad,
@@ -106,25 +57,6 @@ void leapfrog(const F &logp_grad_fun, const Vec<S> &inv_mass, S step,
   logp_grad_fun(theta_next, logp_next, grad_next);
   rho_next.noalias() += half_step * grad_next;
   logp_next += logp_momentum(rho_next, inv_mass);
-}
-
-template <Direction D, typename S>
-inline auto order_forward_backward(S &&s1, S &&s2) {
-  if constexpr (D == Direction::Forward)
-    return std::forward_as_tuple(std::forward<S>(s1), std::forward<S>(s2));
-  else
-    return std::forward_as_tuple(std::forward<S>(s2), std::forward<S>(s1));
-}
-
-template <Direction D, typename S>
-inline bool uturn(const Span<S> &span_1, const Span<S> &span_2,
-                  const Vec<S> &inv_mass) {
-  auto &&[span_bk, span_fw] = order_forward_backward<D>(span_1, span_2);
-  auto scaled_diff =
-      (inv_mass.array() * (span_fw.theta_fw_ - span_fw.theta_bk_).array())
-          .matrix();
-  return span_fw.rho_fw_.dot(scaled_diff) < 0 ||
-         span_bk.rho_bk_.dot(scaled_diff) < 0;
 }
 
 template <Update U, Direction D, typename S, class Generator>

--- a/walnuts_cpp/include/walnuts/util.hpp
+++ b/walnuts_cpp/include/walnuts/util.hpp
@@ -1,0 +1,86 @@
+#ifndef NUTS_UTIL_HPP
+#define NUTS_UTIL_HPP
+
+#include <random>
+
+#include <Eigen/Dense>
+
+namespace nuts {
+
+template <typename S>
+using Vec = Eigen::Matrix<S, Eigen::Dynamic, 1>;
+
+template <typename S>
+using Matrix = Eigen::Matrix<S, Eigen::Dynamic, Eigen::Dynamic>;
+
+using Integer = std::int32_t;
+
+enum class Update { Barker, Metropolis };
+
+enum class Direction { Backward, Forward };
+
+template <typename S, class Generator>
+class Random {
+ public:
+  explicit Random(Generator &rng)
+      : rng_(rng), unif_(0.0, 1.0), binary_(0.5), normal_(0.0, 1.0) {}
+
+  inline S uniform_real_01() { return unif_(rng_); }
+
+  inline bool uniform_binary() { return binary_(rng_); }
+
+  inline Vec<S> standard_normal(Integer n) {
+    return Vec<S>::NullaryExpr(n, [&](Integer) { return normal_(rng_); });
+  }
+
+ private:
+  Generator &rng_;
+  std::uniform_real_distribution<S> unif_;
+  std::bernoulli_distribution binary_;
+  std::normal_distribution<S> normal_;
+};
+
+
+template <typename S>
+S log_sum_exp(const S &x1, const S &x2) {
+  using std::fmax, std::log, std::exp;
+  S m = fmax(x1, x2);
+  return m + log(exp(x1 - m) + exp(x2 - m));
+}
+
+template <typename S>
+S log_sum_exp(const Vec<S> &x) {
+  using std::log;
+  S m = x.maxCoeff();
+  return m + log((x.array() - m).exp().sum());
+}
+
+template <typename S>
+S logp_momentum(const Vec<S> &rho, const Vec<S> &inv_mass) {
+  return -0.5 * rho.dot(inv_mass.cwiseProduct(rho));
+}
+
+template <Direction D, typename S>
+inline auto order_forward_backward(S &&s1, S &&s2) {
+  if constexpr (D == Direction::Forward)
+    return std::forward_as_tuple(std::forward<S>(s1), std::forward<S>(s2));
+  else  // Direction::Backward
+    return std::forward_as_tuple(std::forward<S>(s2), std::forward<S>(s1));
+}
+
+
+// U is either Span or WSpan; order_forward_backward generic
+template <Direction D, typename S, class U>
+inline bool uturn(const U &span_1, const U &span_2,
+                  const Vec<S> &inv_mass) {
+  auto &&[span_bk, span_fw] = order_forward_backward<D>(span_1, span_2);
+  auto scaled_diff =
+      (inv_mass.array() * (span_fw.theta_fw_ - span_fw.theta_bk_).array())
+          .matrix();
+  return span_fw.rho_fw_.dot(scaled_diff) < 0
+         || span_bk.rho_bk_.dot(scaled_diff) < 0;
+}
+
+}
+
+#endif


### PR DESCRIPTION
* refactored all the shared utilities for nuts and walnuts into `util.hpp`
* put everythnig in `nuts` namespace; updated names of different objects (`transition` to `transition_w` for WALNUTS, `Span` to `SpanW` for WALNUTS; all else shared)