### PR TITLE
clang format style, application

### DIFF
--- a/walnuts_cpp/.clang-format
+++ b/walnuts_cpp/.clang-format
@@ -1,1 +1,5 @@
 BasedOnStyle: Google
+InsertBraces: true
+AlwaysBreakBeforeMultilineStrings: false
+AllowShortIfStatementsOnASingleLine: false
+IncludeBlocks: Preserve

--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -56,14 +56,14 @@ target_include_directories(walnuts INTERFACE
   $<INSTALL_INTERFACE:include>                            # for installs
 )
 # 2) Create the “namespace” alias
-add_library(walnuts::walnuts ALIAS walnuts)
+add_library(nuts::nuts ALIAS walnuts)
 
 ##########################
 ##       Example        ##
 ##########################
 if (WALNUTS_BUILD_EXAMPLES)
   add_executable(test_nuts ${CMAKE_CURRENT_SOURCE_DIR}/examples/test.cpp)
-  target_link_libraries(test_nuts PRIVATE Eigen3::Eigen walnuts::walnuts)
+  target_link_libraries(test_nuts PRIVATE Eigen3::Eigen nuts::nuts)
   target_compile_options(test_nuts PRIVATE -O3 -Wall)
 endif()
 
@@ -72,4 +72,28 @@ endif()
 ##########################
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extras/CMakeLists.txt")
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/extras")
+endif()
+
+##########################
+##       Format         ##
+##########################
+# Define list of files to format (you can make this recursive if desired)
+file(GLOB_RECURSE ALL_SOURCE_FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/examples/*.cpp"
+)
+
+find_program(CLANG_FORMAT_BIN clang-format)
+
+if (CLANG_FORMAT_BIN)
+  add_custom_target(
+    format
+    COMMAND ${CLANG_FORMAT_BIN}
+      -i
+      -style=file
+      ${ALL_SOURCE_FILES}
+    COMMENT "Running clang-format on source files"
+  )
+else()
+  message(WARNING "clang-format not found. 'format' target will not be available.")
 endif()

--- a/walnuts_cpp/README.md
+++ b/walnuts_cpp/README.md
@@ -107,6 +107,7 @@ We can also use this to build from the top level directory
 ```bash
 # /usr/bin/bash
 # From walnuts_cpp
+
 # This will take longer as we include depedencies
 # google test and google benchmark
 cmake -S . -B "build" -DCMAKE_BUILD_TYPE=RELEASE
@@ -125,14 +126,23 @@ For all other build types you can add `VERBOSE=1` to your make call to see a tra
 
 ## Formatting
 
-```bash
-pushd walnuts_cpp/include/walnuts
-clang-format -i -style=Google *.hpp
-popd
+After running the build process (see above), all of the `.hpp` files
+in the `include` directory and all of the `.cpp` files in the
+`examples` directory will be formatted.
 
-cd walnuts_cpp/examples/
-clang-format -i -style=Google *.hppcp 
+```bash
+# /usr/bin/bash
+# from walnuts_cpp
+
+# make the project, change to build directory, format
+cmake -S . -B "build" -DCMAKE_BUILD_TYPE=RELEASE
+cd build
+make format
 ```
 
-We chose Google largely style because it's compact.
+The formatting style is defined in the file
+`walnuts_cpp/.clang_format`.  It specifies
 
+* Google format for compactness
+* braces and newlines around conditional and loop bodies
+* include ordering sorted within block, but blocks maintained

--- a/walnuts_cpp/examples/test.cpp
+++ b/walnuts_cpp/examples/test.cpp
@@ -40,8 +40,8 @@ void test_nuts(const VectorS& theta_init, G& generator, int D, int N,
 
   auto global_start = std::chrono::high_resolution_clock::now();
   if constexpr (U == Sampler::Walnuts) {
-    nuts::walnuts(generator, standard_normal_logp_grad<S>, inv_mass,
-                     step_size, max_depth, max_error, theta_init, draws);
+    nuts::walnuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,
+                  max_depth, max_error, theta_init, draws);
   } else if constexpr (U == Sampler::Nuts) {
     nuts::nuts(generator, standard_normal_logp_grad<S>, inv_mass, step_size,
                max_depth, theta_init, draws);

--- a/walnuts_cpp/include/walnuts/util.hpp
+++ b/walnuts_cpp/include/walnuts/util.hpp
@@ -1,9 +1,8 @@
 #ifndef NUTS_UTIL_HPP
 #define NUTS_UTIL_HPP
 
-#include <random>
-
 #include <Eigen/Dense>
+#include <random>
 
 namespace nuts {
 
@@ -40,7 +39,6 @@ class Random {
   std::normal_distribution<S> normal_;
 };
 
-
 template <typename S>
 S log_sum_exp(const S &x1, const S &x2) {
   using std::fmax, std::log, std::exp;
@@ -62,25 +60,24 @@ S logp_momentum(const Vec<S> &rho, const Vec<S> &inv_mass) {
 
 template <Direction D, typename S>
 inline auto order_forward_backward(S &&s1, S &&s2) {
-  if constexpr (D == Direction::Forward)
+  if constexpr (D == Direction::Forward) {
     return std::forward_as_tuple(std::forward<S>(s1), std::forward<S>(s2));
-  else  // Direction::Backward
+  } else {  // Direction::Backward
     return std::forward_as_tuple(std::forward<S>(s2), std::forward<S>(s1));
+  }
 }
-
 
 // U is either Span or WSpan; order_forward_backward generic
 template <Direction D, typename S, class U>
-inline bool uturn(const U &span_1, const U &span_2,
-                  const Vec<S> &inv_mass) {
+inline bool uturn(const U &span_1, const U &span_2, const Vec<S> &inv_mass) {
   auto &&[span_bk, span_fw] = order_forward_backward<D>(span_1, span_2);
   auto scaled_diff =
       (inv_mass.array() * (span_fw.theta_fw_ - span_fw.theta_bk_).array())
           .matrix();
-  return span_fw.rho_fw_.dot(scaled_diff) < 0
-         || span_bk.rho_bk_.dot(scaled_diff) < 0;
+  return span_fw.rho_fw_.dot(scaled_diff) < 0 ||
+         span_bk.rho_bk_.dot(scaled_diff) < 0;
 }
 
-}
+}  // namespace nuts
 
 #endif


### PR DESCRIPTION
Add a `clang-format` target to `cmake` with style file and instrucitons in README.  The style configured so far

* Google as baseline style
* braces and newlines around bodies of conditionals and loops
* ordering includes within blocks but maintaining blocks (so we can have std lib -> dependency -> own includes)