### PR TITLE
Fix Stan example build, really enable ctest

### DIFF
--- a/walnuts_cpp/CMakeLists.txt
+++ b/walnuts_cpp/CMakeLists.txt
@@ -64,7 +64,7 @@ if(WALNUTS_BUILD_STAN)
     )
 
   add_executable(test_stan ${CMAKE_CURRENT_SOURCE_DIR}/examples/test_stan.cpp)
-  target_link_libraries(test_stan PRIVATE Eigen3::Eigen walnuts::walnuts BridgeStan::BridgeStan)
+  target_link_libraries(test_stan PRIVATE Eigen3::Eigen nuts::nuts BridgeStan::BridgeStan)
   target_compile_options(test_stan PRIVATE -O3 -Wall)
 endif()
 
@@ -101,6 +101,7 @@ endif()
 ##       Tests         ##
 ##########################
 if (WALNUTS_BUILD_TESTS)
+  enable_testing()
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
 endif()
 

--- a/walnuts_cpp/examples/test_stan.cpp
+++ b/walnuts_cpp/examples/test_stan.cpp
@@ -37,7 +37,7 @@ void test_nuts(const DynamicStanModel &model, const VectorS &theta_init,
 
   auto global_start = std::chrono::high_resolution_clock::now();
   if constexpr (U == Sampler::Walnuts) {
-    walnuts::walnuts(generator, logp, inv_mass, step_size, max_depth, max_error,
+    nuts::walnuts(generator, logp, inv_mass, step_size, max_depth, max_error,
                      theta_init, N, writer);
   } else if constexpr (U == Sampler::Nuts) {
     nuts::nuts(generator, logp, inv_mass, step_size, max_depth, theta_init, N,

--- a/walnuts_cpp/tests/CMakeLists.txt
+++ b/walnuts_cpp/tests/CMakeLists.txt
@@ -7,7 +7,6 @@ FetchContent_Declare(googletest
 FetchContent_MakeAvailable(googletest)
 
 # Set up testing framework, then add tests
-
 # define a function to add a gtest‐based nuts test
 function(add_nuts_test TEST_NAME TEST_SOURCE)
   # create the executable
@@ -24,11 +23,11 @@ function(add_nuts_test TEST_NAME TEST_SOURCE)
   # register it with CTest
   add_test(
     NAME ${TEST_NAME}
-    COMMAND ${TEST_NAME}
+    COMMAND $<TARGET_FILE:${TEST_NAME}>
   )
 endfunction()
 
-add_nuts_test(mock_test mock_test.cpp) 
-add_nuts_test(welford_test welford_test.cpp) 
-add_nuts_test(dual_average_test dual_average_test.cpp) 
+add_nuts_test(mock_test mock_test.cpp)
+add_nuts_test(welford_test welford_test.cpp)
+add_nuts_test(dual_average_test dual_average_test.cpp)
 


### PR DESCRIPTION
The walnuts -> nuts namespace change wasn't applied to the Stan example program.

Additionally, our existing config did not actually let `ctest` work for me. Adding `enable_testing()` seems to fix it.

Note: the dual averaging test from #39 fails on my machine.